### PR TITLE
Fix/avoid fail to initialize

### DIFF
--- a/CP_SSSSS_Main.cs
+++ b/CP_SSSSS_Main.cs
@@ -67,15 +67,15 @@ public class CP_SSSSS_Main : MonoBehaviour
 			return;
 		}
 
+		CleanupBuffer();
+
 		// Disable the image effect if the shader can't
 		// run on the users graphics card
-		if (!shader || !shader.isSupported)
+		if(shader && !shader.isSupported)
 		{
 			enabled = false;
 			return;
 		}
-
-		CleanupBuffer();
 		if(buffer == null) ApplyBuffer();
 	}
 

--- a/CP_SSSSS_Main.cs
+++ b/CP_SSSSS_Main.cs
@@ -246,7 +246,7 @@ public class CP_SSSSS_Main : MonoBehaviour
 
 	public void AddMakeSSSMaskCommands(CommandBuffer buffer)
 	{
-		if(!Camera.current || TargetMeshes.Count == 0) return;
+		if(TargetMeshes.Count == 0) return;
 
 		for(int i = m_MaskMaterials.Count; i < TargetMeshes.Count; i++) {
 			if(maskShader != null) {

--- a/CP_SSSSS_Main.cs
+++ b/CP_SSSSS_Main.cs
@@ -88,7 +88,6 @@ public class CP_SSSSS_Main : MonoBehaviour
 	void OnPostRender()
 	{
 		TargetMeshes.Clear();
-		Shader.SetGlobalTexture("SSSMaskTexture", null);
 	}
 
 	public struct SSSParameter

--- a/CP_SSSSS_Object.cs
+++ b/CP_SSSSS_Object.cs
@@ -37,7 +37,7 @@ public class CP_SSSSS_Object : MonoBehaviour {
 	{
 		if(r) {
 			var camera = Camera.current;
-			var sssssMain = camera.gameObject.GetComponent<CP_SSSSS_Main>();
+			var sssssMain = camera.GetComponent<CP_SSSSS_Main>();
 			if(sssssMain && sssssMain.isActiveAndEnabled) {
 				if(Application.isPlaying) {
 					for(int i = 0; i < subMeshIndicies.Count; ++i) {


### PR DESCRIPTION
CP_SSSSS_Main Component is disabled when added to GameObject.
This PR fix this inconvenient behaviour.

(Sorry, these are spilt from previous pull request)